### PR TITLE
show env info on unpickle error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ build-backend = "setuptools.build_meta"
 local_scheme = "dirty-tag"
 
 [tool.pytest.ini_options]
-addopts = "--ignore-glob='*integration*' --cov=versioned_pickle"
+# skip integration tests by default with bare 'pytest' (use -m 'integration or not integration' to include)
+addopts = "-m 'not integration' --cov=versioned_pickle"
 
 [tool.black]
 line-length = 100

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,6 +29,7 @@ def with_testpkg_installed():
     else:
         raise Exception("uninstall did not succeed")
 
+
 @pytest.mark.integration
 def test_installed_not_imported(with_testpkg_installed):
     meta_inst = vpickle.EnvironmentMetadata.from_scope(package_scope="installed")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ def with_testpkg_installed():
     else:
         raise Exception("uninstall did not succeed")
 
-
+@pytest.mark.integration
 def test_installed_not_imported(with_testpkg_installed):
     meta_inst = vpickle.EnvironmentMetadata.from_scope(package_scope="installed")
     assert "testing-pkg" in meta_inst.packages

--- a/tests/test_versioned_pickle.py
+++ b/tests/test_versioned_pickle.py
@@ -161,10 +161,11 @@ def test_dump_match(mocker):
     loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
     assert obj_for_roundtrip == loaded_copy
 
-    dumped_bytes = vpickle.dumps(obj_for_roundtrip, 'loaded')
+    dumped_bytes = vpickle.dumps(obj_for_roundtrip, "loaded")
     loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
     assert obj_for_roundtrip == loaded_copy
-    assert meta.package_scope == 'loaded'
+    assert meta.package_scope == "loaded"
+
 
 def test_dump_mismatch(mocker):
     # need an object whose parts can be compared reasonably for equality
@@ -174,6 +175,7 @@ def test_dump_mismatch(mocker):
     assert obj_for_roundtrip == loaded_copy
 
     from versioned_pickle import get_version as unpatched_version_import
+
     mocker.patch(
         "versioned_pickle.get_version",
         new=lambda x: "dummy" if x == "requests" else unpatched_version_import(x),
@@ -185,24 +187,31 @@ def test_dump_mismatch(mocker):
         loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
         assert obj_for_roundtrip == loaded_copy
 
+
 @dataclasses.dataclass
 class UnLoadable:
     """Need an object that can be pickled but errors on unpickle"""
+
     x: ... = None
+
     def __getstate__(self):
         return self.__dict__
+
     def __setstate__(self, state):
         assert False
 
+
 def test_load_with_error(mocker, requests_imported):
     obj = UnLoadable()
-    dumped_bytes = vpickle.dumps(obj, package_scope='loaded')
+    dumped_bytes = vpickle.dumps(obj, package_scope="loaded")
 
     from versioned_pickle import get_version as unpatched_version_import
+
     mocker.patch(
         "versioned_pickle.get_version",
         new=lambda x: "dummy" if x == "requests" else unpatched_version_import(x),
     )
-    with pytest.raises(vpickle.PackageMismatchWarning, match="Encountered an error when unpickling"):
+    with pytest.raises(
+        vpickle.PackageMismatchWarning, match="Encountered an error when unpickling"
+    ):
         vpickle.loads(dumped_bytes)
-

--- a/tests/test_versioned_pickle.py
+++ b/tests/test_versioned_pickle.py
@@ -28,7 +28,7 @@ class MyCls:
 
 
 @fixture
-def import_module():
+def requests_imported():
     """For tests that assume requests is imported."""
     import requests
 
@@ -36,7 +36,7 @@ def import_module():
 
 
 @fixture
-def sample_object(import_module):
+def sample_object(requests_imported):
     """This object tests different types of values and structures including a class instance, a class object,
     reference to a nested module requests.auth, and a function.
     Tests recursing into containers and instance attrs.
@@ -56,7 +56,7 @@ def test_pickler(sample_object):
 class TestEnvMetadata:
     """Test instantiation of EnvironmentMetadata"""
 
-    def test_env_metadata_loaded(self, import_module):
+    def test_env_metadata_loaded(self, requests_imported):
         meta = vpickle.EnvironmentMetadata.from_scope(package_scope="loaded")
         assert "requests" in meta.packages
 
@@ -154,17 +154,29 @@ def test_metadata_validate():
     assert isinstance(meta_pickled.validate_against(meta_loaded), vpickle.PackageMismatchWarning)
 
 
-def test_dump(mocker):
+def test_dump_match(mocker):
     # need an object whose parts can be compared reasonably for equality
     obj_for_roundtrip = [MyCls("foo"), requests.Request]
     dumped_bytes = vpickle.dumps(obj_for_roundtrip)
     loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
     assert obj_for_roundtrip == loaded_copy
-    from versioned_pickle import get_version as local_version_import
 
+    dumped_bytes = vpickle.dumps(obj_for_roundtrip, 'loaded')
+    loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
+    assert obj_for_roundtrip == loaded_copy
+    assert meta.package_scope == 'loaded'
+
+def test_dump_mismatch(mocker):
+    # need an object whose parts can be compared reasonably for equality
+    obj_for_roundtrip = [MyCls("foo"), requests.Request]
+    dumped_bytes = vpickle.dumps(obj_for_roundtrip)
+    loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
+    assert obj_for_roundtrip == loaded_copy
+
+    from versioned_pickle import get_version as unpatched_version_import
     mocker.patch(
         "versioned_pickle.get_version",
-        new=lambda x: "dummy" if x == "requests" else local_version_import(x),
+        new=lambda x: "dummy" if x == "requests" else unpatched_version_import(x),
     )
     with pytest.warns(
         vpickle.PackageMismatchWarning,
@@ -172,3 +184,25 @@ def test_dump(mocker):
     ) as record:
         loaded_copy, meta = vpickle.loads(dumped_bytes, return_meta=True)
         assert obj_for_roundtrip == loaded_copy
+
+@dataclasses.dataclass
+class UnLoadable:
+    """Need an object that can be pickled but errors on unpickle"""
+    x: ... = None
+    def __getstate__(self):
+        return self.__dict__
+    def __setstate__(self, state):
+        assert False
+
+def test_load_with_error(mocker, requests_imported):
+    obj = UnLoadable()
+    dumped_bytes = vpickle.dumps(obj, package_scope='loaded')
+
+    from versioned_pickle import get_version as unpatched_version_import
+    mocker.patch(
+        "versioned_pickle.get_version",
+        new=lambda x: "dummy" if x == "requests" else unpatched_version_import(x),
+    )
+    with pytest.raises(vpickle.PackageMismatchWarning, match="Encountered an error when unpickling"):
+        vpickle.loads(dumped_bytes)
+


### PR DESCRIPTION
Previously, vpickle showed you a mismatch warning if the unpickling succeeded so as to prevent silent errors, but if the pickle loading failed outright then so would vpickle. (Users had to manually recover and read just the metadata if they really wanted it.)

Now, we are more helpful in case of load failure by raising an exception noting the mismatch and details (wrapping the original exception). 